### PR TITLE
Fix webhook notifications for LNbits v1

### DIFF
--- a/internal/lnbits/webhook/webhook.go
+++ b/internal/lnbits/webhook/webhook.go
@@ -34,7 +34,7 @@ type Server struct {
 
 type Webhook struct {
 	CheckingID    string      `json:"checking_id"`
-	Pending       bool        `json:"pending"`
+	Status        string      `json:"status"`  // LNbits v1: "success" or "pending"
 	Amount        int64       `json:"amount"`
 	Fee           int64       `json:"fee"`
 	Memo          string      `json:"memo"`
@@ -42,7 +42,7 @@ type Webhook struct {
 	Bolt11        string      `json:"bolt11"`
 	Preimage      string      `json:"preimage"`
 	PaymentHash   string      `json:"payment_hash"`
-	Extra         struct{}    `json:"extra"`
+	Extra         interface{} `json:"extra"`
 	WalletID      string      `json:"wallet_id"`
 	Webhook       string      `json:"webhook"`
 	WebhookStatus interface{} `json:"webhook_status"`
@@ -97,21 +97,34 @@ func (w *Server) receive(writer http.ResponseWriter, request *http.Request) {
 	}
 	log.Debugf("[Webhook] Raw payload: %s", string(rawBody))
 
+	// LNbits v1 sends the payload as a double-encoded JSON string (the body
+	// is a JSON string containing escaped JSON). Try normal decode first;
+	// if that fails, unquote the string and decode the inner JSON.
+	payload := rawBody
 	webhookEvent := Webhook{}
-	err = json.NewDecoder(bytes.NewReader(rawBody)).Decode(&webhookEvent)
+	err = json.NewDecoder(bytes.NewReader(payload)).Decode(&webhookEvent)
 	if err != nil {
-		log.Errorf("[Webhook] Error decoding request: %s", err.Error())
-		log.Errorf("[Webhook] Body was: %s", string(rawBody))
-		writer.WriteHeader(400)
-		return
+		// Try unquoting: the body might be a JSON string wrapping the real object
+		var inner string
+		if unquoteErr := json.Unmarshal(rawBody, &inner); unquoteErr == nil {
+			payload = []byte(inner)
+			err = json.Unmarshal(payload, &webhookEvent)
+		}
+		if err != nil {
+			log.Errorf("[Webhook] Error decoding request: %s", err.Error())
+			log.Errorf("[Webhook] Body was: %s", string(rawBody))
+			writer.WriteHeader(400)
+			return
+		}
 	}
 
-	log.Infof("[Webhook] Decoded: payment_hash=%s wallet_id=%s pending=%v amount=%d",
-		webhookEvent.PaymentHash, webhookEvent.WalletID, webhookEvent.Pending, webhookEvent.Amount)
+	log.Infof("[Webhook] Decoded: payment_hash=%s wallet_id=%s status=%s amount=%d",
+		webhookEvent.PaymentHash, webhookEvent.WalletID, webhookEvent.Status, webhookEvent.Amount)
 
-	// Ignore pending (unpaid) payments — only process settled payments
-	if webhookEvent.Pending {
-		log.Infof("[Webhook] Ignoring pending payment (payment_hash=%s)", webhookEvent.PaymentHash)
+	// Ignore non-settled payments — LNbits v1 uses "status" field ("success" = settled)
+	if webhookEvent.Status != "success" {
+		log.Infof("[Webhook] Ignoring non-success payment (status=%s, payment_hash=%s)",
+			webhookEvent.Status, webhookEvent.PaymentHash)
 		writer.WriteHeader(200)
 		return
 	}

--- a/internal/lnbits/webhook/webhook.go
+++ b/internal/lnbits/webhook/webhook.go
@@ -1,8 +1,10 @@
 package webhook
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/LightningTipBot/LightningTipBot/internal"
@@ -84,19 +86,32 @@ func (w *Server) newRouter() *mux.Router {
 }
 
 func (w *Server) receive(writer http.ResponseWriter, request *http.Request) {
-	log.Debugln("[Webhook] Received request")
+	log.Infoln("[Webhook] Received request")
+
+	// Read the raw body so we can log it for debugging and still decode it
+	rawBody, err := io.ReadAll(request.Body)
+	if err != nil {
+		log.Errorf("[Webhook] Error reading request body: %s", err.Error())
+		writer.WriteHeader(400)
+		return
+	}
+	log.Debugf("[Webhook] Raw payload: %s", string(rawBody))
+
 	webhookEvent := Webhook{}
-	// Strip content-length header to prevent Decode failures on some clients
-	request.Header.Del("content-length")
-	err := json.NewDecoder(request.Body).Decode(&webhookEvent)
+	err = json.NewDecoder(bytes.NewReader(rawBody)).Decode(&webhookEvent)
 	if err != nil {
 		log.Errorf("[Webhook] Error decoding request: %s", err.Error())
+		log.Errorf("[Webhook] Body was: %s", string(rawBody))
 		writer.WriteHeader(400)
 		return
 	}
 
+	log.Infof("[Webhook] Decoded: payment_hash=%s wallet_id=%s pending=%v amount=%d",
+		webhookEvent.PaymentHash, webhookEvent.WalletID, webhookEvent.Pending, webhookEvent.Amount)
+
 	// Ignore pending (unpaid) payments — only process settled payments
 	if webhookEvent.Pending {
+		log.Infof("[Webhook] Ignoring pending payment (payment_hash=%s)", webhookEvent.PaymentHash)
 		writer.WriteHeader(200)
 		return
 	}

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -57,6 +57,9 @@ func NewBot() TipBot {
 		Cache:    Cache{GoCacheStore: gocacheStore},
 	}
 	poller.bot = &bot
+	// register invoice callbacks early so the webhook server can dispatch
+	// events immediately after it starts (before bot.Start is called)
+	initInvoiceEventCallbacks(&bot)
 	return bot
 }
 
@@ -127,9 +130,6 @@ func (bot *TipBot) Start() {
 	// edit worker collects messages to edit and
 	// periodically edits them
 	bot.startEditWorker()
-
-	// register callbacks for invoices
-	initInvoiceEventCallbacks(bot)
 
 	// register callbacks for user state changes
 	initializeStateCallbackMessage(bot)


### PR DESCRIPTION
## Summary
- Fix webhook payload parsing for LNbits v1 (double-encoded JSON string, status replacing pending)
- Add diagnostic logging to webhook handler (INFO level for production visibility)
- Fix callback initialization race condition (register before webhook server starts)

## Verified in production
- Webhook notifications received in Telegram when sats arrive via lightning address
- LNURL comments forwarded correctly

Closes #12